### PR TITLE
Fix to use PySide2 or PySide6

### DIFF
--- a/freecad/invgears/newAnimatorCmd.py
+++ b/freecad/invgears/newAnimatorCmd.py
@@ -24,7 +24,7 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 
-from PySide2.QtWidgets import QDialogButtonBox
+from PySide.QtWidgets import QDialogButtonBox
 
 from freecad.invgears.animator import Animator, AnimatorVP
 

--- a/freecad/invgears/newInternalCmd.py
+++ b/freecad/invgears/newInternalCmd.py
@@ -24,7 +24,7 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 import os
-from PySide6.QtWidgets import QDialogButtonBox
+from PySide.QtWidgets import QDialogButtonBox
 
 from freecad.invgears.featureClasses import InternalGear, SlaveGear, ViewProviderInternalGear, ViewProviderSlaveGear
 

--- a/freecad/invgears/newMasterBevelCmd.py
+++ b/freecad/invgears/newMasterBevelCmd.py
@@ -24,7 +24,7 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 import os
-from PySide6.QtWidgets import QDialogButtonBox
+from PySide.QtWidgets import QDialogButtonBox
 
 from freecad.invgears.featureClasses import MasterBevelGear, SlaveBevelGear, ViewProviderMasterBevelGear, ViewProviderSlaveBevelGear
 

--- a/freecad/invgears/newMasterCmd.py
+++ b/freecad/invgears/newMasterCmd.py
@@ -25,7 +25,7 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import os
 
-from PySide6.QtWidgets import QDialogButtonBox
+from PySide.QtWidgets import QDialogButtonBox
 from freecad.invgears.featureClasses import MasterGear, SlaveGear, ViewProviderMasterGear, ViewProviderSlaveGear
 
 

--- a/freecad/invgears/newSVGCmd.py
+++ b/freecad/invgears/newSVGCmd.py
@@ -24,7 +24,7 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 
-from PySide6.QtWidgets import QDialogButtonBox, QFileDialog
+from PySide.QtWidgets import QDialogButtonBox, QFileDialog
 
 from freecad.invgears.svgFile import GearsInSVG
 from freecad.invgears.observers import SelObserver

--- a/freecad/invgears/newSlaveCmd.py
+++ b/freecad/invgears/newSlaveCmd.py
@@ -24,7 +24,7 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 import os
-from PySide6.QtWidgets import QDialogButtonBox
+from PySide.QtWidgets import QDialogButtonBox
 
 from freecad.invgears.featureClasses import SlaveGear, ViewProviderSlaveGear
 from freecad.invgears.observers import SelObserver

--- a/freecad/invgears/newSlaveMasterCmd.py
+++ b/freecad/invgears/newSlaveMasterCmd.py
@@ -24,7 +24,7 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 import os
-from PySide6.QtWidgets import QDialogButtonBox
+from PySide.QtWidgets import QDialogButtonBox
 
 from freecad.invgears.featureClasses import SlaveMasterGear, ViewProviderSlaveMasterGear
 from freecad.invgears.observers import SelObserver

--- a/freecad/invgears/rc_invGears.py
+++ b/freecad/invgears/rc_invGears.py
@@ -7,7 +7,7 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PySide6 import QtCore
+from PySide import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x06\xc7\


### PR DESCRIPTION
This way you can use the development version 1.1, the stable version 1.0 or earlier.